### PR TITLE
Sets author in gemspec to avoid installation warnings with latest RubyGem

### DIFF
--- a/enum_column.gemspec
+++ b/enum_column.gemspec
@@ -6,6 +6,7 @@
 Gem::Specification.new do |s|
   s.name = %q{enum_column}
   s.version = "0.7.0"
+  s.author = "electronick"
 
   s.files = [
      "README.txt",


### PR DESCRIPTION
Sets author in gemspec to avoid installation warnings with latest RubyGems
