### PR TITLE
Rails 3.2 Compatibility

### DIFF
--- a/lib/enum/enum_adapter.rb
+++ b/lib/enum/enum_adapter.rb
@@ -1,11 +1,18 @@
-
 # This module provides all the column helper methods to deal with the
 # values and adds the common type management code for the adapters.
 
+
+# try rails 3.1, then rails 3.2+, mysql column adapters
 column_class = if defined? ActiveRecord::ConnectionAdapters::Mysql2Column
   ActiveRecord::ConnectionAdapters::Mysql2Column
-else
+elsif defined? ActiveRecord::ConnectionAdapters::MysqlColumn
   ActiveRecord::ConnectionAdapters::MysqlColumn
+elsif defined? ActiveRecord::ConnectionAdapters::Mysql2Adapter::Column
+  ActiveRecord::ConnectionAdapters::Mysql2Adapter::Column
+elsif defined? ActiveRecord::ConnectionAdapters::MysqlAdapter::Column
+  ActiveRecord::ConnectionAdapters::MysqlAdapter::Column
+else
+  ObviousHint::NoMysqlAdapterFound
 end
 
 column_class.module_eval do


### PR DESCRIPTION
Adapter name changed a bit. Support for < 3.2 is unchanged.
