### PR TITLE
extract_limit regexp

### DIFF
--- a/lib/enum/enum_adapter.rb
+++ b/lib/enum/enum_adapter.rb
@@ -75,7 +75,7 @@ private
   alias __extract_limit_enum extract_limit
   def extract_limit(sql_type)
     if sql_type =~ /^enum/i
-      sql_type.sub(/^enum\('([^)]+)'\)/i, '\1').split("','").map { |v| v.intern }
+      sql_type.sub(/^enum\('(.+)'\)/i, '\1').split("','").map { |v| v.intern }
     else
       __extract_limit_enum(sql_type)
     end


### PR DESCRIPTION
replaced ^[)] with .
because regexps are greedy and the old regexp doesn't allow enum-values with brackets.
