### PR TITLE
switching to strings in enum limits

### DIFF
--- a/lib/enum/enum_adapter.rb
+++ b/lib/enum/enum_adapter.rb
@@ -75,7 +75,7 @@ private
   alias __extract_limit_enum extract_limit
   def extract_limit(sql_type)
     if sql_type =~ /^enum/i
-      sql_type.sub(/^enum\('(.+)'\)/i, '\1').split("','").map { |v| v.intern }
+      sql_type.sub(/^enum\('(.+)'\)/i, '\1').split("','").map { |v| "#{v}" }
     else
       __extract_limit_enum(sql_type)
     end


### PR DESCRIPTION
I switched the type of the enums limit array contents from symbols to strings, as enums with values like "!" resulted in invalid symbols ( :! )
enums look now like this:

t.enum "action", :limit => ["-", "s", "i", "c", "!"]
