### PR TITLE
Avoid typecasting unexpected strings to symbols to prevent DoS due to memory leak

### DIFF
--- a/lib/enum/enum_adapter.rb
+++ b/lib/enum/enum_adapter.rb
@@ -73,7 +73,7 @@ private
   end
 
   def string_to_valid_enum_hash_code
-    Hash[limit.map(&:to_s).zip(limit)].to_s
+    Hash[enum_valid_string_assoc].to_s
   end
 
   def enum_valid_string_assoc


### PR DESCRIPTION
This gem will typecast any string to a symbol when assigned to an enum column, even if the string does not fit the enum. This exposes a [potential DoS vulnerability](http://threebrothers.org/brendan/blog/memory-and-ruby-symbols/) with common usage.  Consider a model Enumeration with an enum column "color". Suppose a user fakes a form submit with the parameter `color=invalid_color`. The controller methods below will catch this in validation and prevent the model from being saved, but the symbol `:invalid_color` will still be created. Since symbols are never garbage-collected, a bunch of requests with random color params will eventually crash the server.

``` ruby
class EnumerationController < ApplicationController
  def new
    e = Enumeration.new(params) #symbol is created here
    e.save #validations fail here if turned on
  end
  def update
    Enumeration.find(params[:id]).update_attributes(params)
  end
end
```

This patch changes functionality slightly so that if an enum attribute is set to an invalid string, it'll just typecast it to nil instead of converting it to a symbol. You can bypass this by assigning the symbol directly.

``` ruby
Enumeration.color = 'invalid' # Enumeration.color == nil
Enumeration.color = :invalid #  Enumeration.color == :invalid
```

What do you think?
