### PR TITLE
Update enum_column for Rails 4.1

### DIFF
--- a/lib/enum/enum_adapter.rb
+++ b/lib/enum/enum_adapter.rb
@@ -37,13 +37,15 @@ column_class.module_eval do
     end
   end
 
-  alias __type_cast_code_enum type_cast_code
-  # Code to convert to a symbol.
-  def type_cast_code(var_name)
-    if type == :enum
-      "#{self.class.name}.value_to_symbol(#{var_name})"
-    else
-      __type_cast_code_enum(var_name)
+  if respond_to?(:type_cast_code)
+    alias __type_cast_code_enum type_cast_code
+    # Code to convert to a symbol.
+    def type_cast_code(var_name)
+      if type == :enum
+        "#{self.class.name}.value_to_symbol(#{var_name})"
+      else
+        __type_cast_code_enum(var_name)
+      end
     end
   end
 


### PR DESCRIPTION
- lib/enum/enum_adapter.rb
  type_cast_code is removed in Rails 4.1
