### PR TITLE
Generate consistent schema.rb files under rails 4.1.x

### DIFF
--- a/lib/enum/abstract_mysql_adapter.rb
+++ b/lib/enum/abstract_mysql_adapter.rb
@@ -1,0 +1,37 @@
+adapter_class = if defined? ActiveRecord::ConnectionAdapters::MysqlAdapter
+  ActiveRecord::ConnectionAdapters::MysqlAdapter
+end
+
+if adapter_class
+  adapter_class.module_eval do
+    protected
+  
+    def initialize_type_map(m) # :nodoc:
+      super
+      # m.register_type(%r(enum)i) do |sql_type|
+      #   limit = sql_type[/^enum\((.+)\)/i, 1]
+      #     .split(',').map{|enum| enum.strip.length - 2}.max
+      #   Type::String.new(limit: limit)
+      # end
+  
+      m.register_type %r(tinytext)i,   Type::Text.new(limit: 255)
+      m.register_type %r(tinyblob)i,   Type::Binary.new(limit: 255)
+      m.register_type %r(mediumtext)i, Type::Text.new(limit: 16777215)
+      m.register_type %r(mediumblob)i, Type::Binary.new(limit: 16777215)
+      m.register_type %r(longtext)i,   Type::Text.new(limit: 2147483647)
+      m.register_type %r(longblob)i,   Type::Binary.new(limit: 2147483647)
+      m.register_type %r(^bigint)i,    Type::Integer.new(limit: 8)
+      m.register_type %r(^int)i,       Type::Integer.new(limit: 4)
+      m.register_type %r(^mediumint)i, Type::Integer.new(limit: 3)
+      m.register_type %r(^smallint)i,  Type::Integer.new(limit: 2)
+      m.register_type %r(^tinyint)i,   Type::Integer.new(limit: 1)
+      m.register_type %r(^float)i,     Type::Float.new(limit: 24)
+      m.register_type %r(^double)i,    Type::Float.new(limit: 53)
+  
+      m.alias_type %r(tinyint\(1\))i,  'boolean' if emulate_booleans
+      m.alias_type %r(set)i,           'varchar'
+      m.alias_type %r(year)i,          'integer'
+      m.alias_type %r(bit)i,           'binary'
+    end
+  end
+end

--- a/lib/enum/enum_adapter.rb
+++ b/lib/enum/enum_adapter.rb
@@ -27,24 +27,26 @@ column_class.module_eval do
     end
   end
 
-  alias __type_cast_enum type_cast
-  # Convert to a symbol.
-  def type_cast(value)
-    if type == :enum
-      self.class.value_to_symbol(value)
-    else
-      __type_cast_enum(value)
-    end
-  end
-
-  if respond_to?(:type_cast_code)
-    alias __type_cast_code_enum type_cast_code
-    # Code to convert to a symbol.
-    def type_cast_code(var_name)
+  if Rails::VERSION::MAJOR < 4
+    alias __type_cast_enum type_cast
+    # Convert to a symbol.
+    def type_cast(value)
       if type == :enum
-        "#{self.class.name}.value_to_symbol(#{var_name})"
+        self.class.value_to_symbol(value)
       else
-        __type_cast_code_enum(var_name)
+        __type_cast_enum(value)
+      end
+    end
+
+    if respond_to?(:type_cast_code)
+      alias __type_cast_code_enum type_cast_code
+      # Code to convert to a symbol.
+      def type_cast_code(var_name)
+        if type == :enum
+          "#{self.class.name}.value_to_symbol(#{var_name})"
+        else
+          __type_cast_code_enum(var_name)
+        end
       end
     end
   end
@@ -63,7 +65,7 @@ column_class.module_eval do
     end
   end
 
-private
+  private
   alias __simplified_type_enum simplified_type
   # The enum simple type.
   def simplified_type(field_type)
@@ -73,7 +75,7 @@ private
       __simplified_type_enum(field_type)
     end
   end
-  
+
   alias __extract_limit_enum extract_limit
   def extract_limit(sql_type)
     if sql_type =~ /^enum/i

--- a/lib/enum_column.rb
+++ b/lib/enum_column.rb
@@ -3,6 +3,7 @@ if defined?(::Rails::Railtie)
     initializer 'enum_column.initialize', :after => 'active_record.initialize_database' do |app|
       ActiveSupport.on_load :active_record do
         require 'enum/mysql_adapter'
+        require 'enum/abstract_mysql_adapter'
         require 'enum/enum_adapter'
         require 'enum/schema_statements'
         require 'enum/schema_definitions'


### PR DESCRIPTION
When schema.rb files are generated using rails 4.1.x for projects with enum_column, enum columns are converted to rails' use of integers for enum's.  The attached change should preserve enum_column's historical behavior.
